### PR TITLE
refactor: update code to use latest API changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
+        "@types/dom-chromium-ai": "^0.0.7",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -1298,6 +1299,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/dom-chromium-ai": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/dom-chromium-ai/-/dom-chromium-ai-0.0.7.tgz",
+      "integrity": "sha512-nt1pTKmvEWjrAq/QuFEpcXYsTGZwuSdPhGNJf6YtMZDiLkQJcEq8znZImO9ABnHEoYbSX899ez3YUZmlE7fkYw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@types/dom-chromium-ai": "^0.0.7",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",


### PR DESCRIPTION
This PR updates the code to accommodate recent changes in the Chrome built-in AI API, which broke existing integrations.

Changes:
- Updated the API usage to match the latest version.
- Replaced custom type definitions with the official `@types/dom-chromium-ai` package.
- Kept the original code structure and variable names intact to minimize disruption.

My reference was [webmachinelearning/prompt-api](https://github.com/webmachinelearning/prompt-api), and the changes in this PR are limited to the Prompt API Playground. As far as I know, other APIs like `Summarizer`, `Writer`, and `Translator` have also changed. I’d be happy to collaborate on updating those as well, since I believe this is a great project to experiment with client-side AI capabilities.